### PR TITLE
アイテム詳細ページの画像切替の実装

### DIFF
--- a/app/assets/javascripts/item/image_change.js
+++ b/app/assets/javascripts/item/image_change.js
@@ -1,0 +1,19 @@
+$(function () {
+  $('.owl-dot').first().addClass("active"); //リストの最初の画像をｚactiveにする
+
+  // 画像切替
+  $('.owl-dot').hover(
+    function () {
+      const hoverImage = $(this).find('img').attr('src')
+      $('.owl-item-inner img').attr('src', hoverImage) 
+    },
+  )
+
+  // activeな画像がハッキリと描写される
+  $('.owl-dot').hover(
+    function () {
+      $('.owl-dot').removeClass("active");
+      $(this).addClass("active");
+    }
+  )
+})

--- a/app/assets/javascripts/shared/global-header.js
+++ b/app/assets/javascripts/shared/global-header.js
@@ -1,0 +1,24 @@
+$(function () {
+  // hover時の色変更jsです
+
+  // leftメニュー
+  $('.pc-header-nav-root').hover(
+    function () {
+      $(this).find('span').css('color', '#0095ee')
+    },
+    function () {
+      $(this).find('span').css('color', '#333')
+    }
+  )
+
+  // rightメニュー
+  $('.menu-link').hover(
+    function () {
+      $(this).children().css('color', '#0095ee')
+    },
+    function () {
+      $(this).children().css('color', '#ccc')
+      $(this).find('span').css('color', '#333')
+    }
+  )
+})

--- a/app/assets/stylesheets/_products_details.scss
+++ b/app/assets/stylesheets/_products_details.scss
@@ -43,11 +43,11 @@
             max-height: none;
             position: relative;
             overflow: hidden;
-            display: inline-block;
             width: 20%;
             max-height: 90px;
             opacity: 0.4;
             cursor: pointer;
+            float: left;
             &.active {
               opacity: 1;
               cursor: default;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -19,7 +19,7 @@
           .owl-next next
         .owl-dots
           - @item.images.each do |image|
-            .owl-dot.active
+            .owl-dot
               %span
               .owl-dot-inner
                 = image_tag image


### PR DESCRIPTION
## What
サムネイルをホバーした時、メインの画像がそれに合わせて変更されるようにする

## Why
投稿されたアイテムを、購入検討しやすくするため